### PR TITLE
add Razer Mamba (wired) support

### DIFF
--- a/data/devices/mouse.json
+++ b/data/devices/mouse.json
@@ -21,5 +21,18 @@
         "features": ["dpi", "poll_rate"],
         "max_dpi": 16000,
         "quirks": ["mouse_matrix", "matrix_brightness"]
+    },
+    {
+        "name": "Razer Mamba",
+        "vid": "1532",
+        "pid": "0044",
+        "type": "mouse",
+        "pclass": "matrix",
+        "leds": [5],
+        "fx": ["off", "breathing", "breathing_dual", "breathing_random", "reactive", "spectrum", "static", "wave", "custom_frame", "brightness"],
+        "features": ["dpi", "poll_rate"],
+        "max_dpi": 16000,
+        "quirks": ["firefly_custom_frame"],
+        "matrix_dimensions": [1, 15]
     }
 ]


### PR DESCRIPTION
This commit adds support for the Razer Mamba (wired only since I don't have time to find my wireless adapter or to add the battery/charger bits)

However, this is very likely to be rejected, because it uses the Firefly-brand "firefly_custom_frame" quirk to get custom effects to work.
