### PR TITLE
Add support for Mamba TE, Base Station and HDK

### DIFF
--- a/data/devices/accessory.json
+++ b/data/devices/accessory.json
@@ -1,0 +1,13 @@
+[
+    {
+        "name": "Razer Base Station Chroma",
+        "vid": "1532",
+        "pid": "0f08",
+        "type": "accessory",
+        "pclass": "matrix",
+        "leds": [5],
+        "fx": ["custom_frame", "brightness"],
+        "quirks": ["matrix_brightness", "mouse_matrix"],
+        "matrix_dimensions": [1, 14]
+    }
+]

--- a/data/devices/accessory.json
+++ b/data/devices/accessory.json
@@ -9,5 +9,16 @@
         "fx": ["custom_frame", "brightness"],
         "quirks": ["matrix_brightness", "mouse_matrix"],
         "matrix_dimensions": [1, 14]
+    },
+    {
+        "name": "Razer Hardware Development Kit",
+        "vid": "1532",
+        "pid": "0f09",
+        "type": "accessory",
+        "pclass": "matrix",
+        "leds": [5],
+        "fx": ["custom_frame", "brightness"],
+        "quirks": ["matrix_brightness", "mouse_matrix"],
+        "matrix_dimensions": [4, 15]
     }
 ]

--- a/data/devices/mouse.json
+++ b/data/devices/mouse.json
@@ -21,5 +21,18 @@
         "features": ["dpi", "poll_rate"],
         "quirks": ["mouse_matrix", "matrix_brightness"],
         "max_dpi": 16000
+    },
+    {
+        "name": "Razer Mamba Tournament Edition",
+        "vid": "1532",
+        "pid": "0046",
+        "type": "mouse",
+        "pclass": "matrix",
+        "leds": [5],
+        "fx": ["off", "breathing", "breathing_dual", "breathing_random", "reactive", "spectrum", "static", "wave", "brightness", "custom_frame"],
+        "features": ["dpi"],
+        "quirks": ["firefly_custom_frame"],
+        "max_dpi": 16000,
+        "matrix_dimensions": [1, 16]
     }
 ]


### PR DESCRIPTION
* HDK almost there - custom frames are not yet rendered on the device.
* Requires patches from [`no_get_brightness`](https://github.com/z3ntu/razer_test/tree/no_get_brightness) branch.