### PR TITLE
Add BlackWidow Chroma V2 Support

### DIFF
--- a/data/devices/keyboard.json
+++ b/data/devices/keyboard.json
@@ -21,4 +21,15 @@
         "features": ["keyboard_layout"],
         "matrix_dimensions": [6, 22]
     }
+        {
+        "name": "Razer BlackWidow Chroma V2",
+        "vid": "1532",
+        "pid": "0221",
+        "type": "keyboard",
+        "pclass": "matrix",
+        "leds": [5],
+        "fx": ["off", "static", "breathing", "breathing_dual", "breathing_random", "spectrum", "wave", "reactive", "custom_frame", "brightness"],
+        "features": ["keyboard_layout"],
+        "matrix_dimensions": [6, 22]
+    },
 ]

--- a/data/devices/keyboard.json
+++ b/data/devices/keyboard.json
@@ -20,8 +20,8 @@
         "fx": ["off", "static", "breathing", "breathing_dual", "breathing_random", "spectrum", "wave", "reactive", "custom_frame", "brightness"],
         "features": ["keyboard_layout"],
         "matrix_dimensions": [6, 22]
-    }
-        {
+    },
+    {
         "name": "Razer BlackWidow Chroma V2",
         "vid": "1532",
         "pid": "0221",
@@ -31,5 +31,5 @@
         "fx": ["off", "static", "breathing", "breathing_dual", "breathing_random", "spectrum", "wave", "reactive", "custom_frame", "brightness"],
         "features": ["keyboard_layout"],
         "matrix_dimensions": [6, 22]
-    },
+    }
 ]


### PR DESCRIPTION
Razer BlackWidow Chroma V2

Supports starlight, but did not include it here with fx.